### PR TITLE
jsonformat protocol

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -766,6 +766,18 @@ class timedelta:
     def __reduce__(self):
         return (self.__class__, self._getstate())
 
+    # jsonformat support.
+
+    def jsonformat(self):
+        mm, ss = divmod(self._seconds, 60)
+        hh, mm = divmod(mm, 60)
+        hh += self._days * 24
+        if self.microseconds:
+            return 'PT%dH%dM%d.%dS' % (hh, mm, ss, self.microseconds)
+        else:
+            return 'PT%dH%dM%dS' % (hh, mm, ss)
+
+
 timedelta.min = timedelta(-999999999)
 timedelta.max = timedelta(days=999999999, hours=23, minutes=59, seconds=59,
                           microseconds=999999)
@@ -1071,6 +1083,10 @@ class date:
 
     def __reduce__(self):
         return (self.__class__, self._getstate())
+
+    # jsonformat support.
+
+    jsonformat = isoformat
 
 _date_class = date  # so functions w/ args named "date" can get at the class
 
@@ -1479,6 +1495,11 @@ class time:
 
     def __reduce__(self):
         return self.__reduce_ex__(2)
+
+    # jsonformat support.
+
+    def jsonformat(self):
+        return self.isoformat()
 
 _time_class = time  # so functions w/ args named "time" can get at the class
 
@@ -2078,6 +2099,11 @@ class datetime(date):
 
     def __reduce__(self):
         return self.__reduce_ex__(2)
+
+    # jsonformat support.
+
+    def jsonformat(self):
+        return self.isoformat()
 
 
 datetime.min = datetime(1, 1, 1)

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -435,8 +435,12 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 if markerid in markers:
                     raise ValueError("Circular reference detected")
                 markers[markerid] = o
-            o = _default(o)
+            if hasattr(o, 'jsonformat'):
+                o = o.jsonformat()
+            else:
+                o = _default(o)
             yield from _iterencode(o, _current_indent_level)
             if markers is not None:
                 del markers[markerid]
+
     return _iterencode

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime, time, timedelta, timezone
 from io import StringIO
 from test.test_json import PyTest, CTest
 
@@ -51,10 +52,44 @@ class TestDump:
         class C:
             def jsonformat(self):
                 return 'hi there'
-        
+
         self.assertEqual(self.dumps({'v': C()}),
                          '{"v": "hi there"}')
 
+    def test_encode_datetime(self):
+        then = datetime(2018, 11, 5, 7, 54, 55, 123456)
+        self.assertEqual(self.dumps({'then': then}),
+                         '{"then": "2018-11-05T07:54:55.123"}')
+
+        then = then.replace(tzinfo=timezone.utc)
+        self.assertEqual(self.dumps({'then': then}),
+                         '{"then": "2018-11-05T07:54:55.123+00:00"}')
+
+    def test_encode_date(self):
+        then = date(2018, 11, 5)
+        self.assertEqual(self.dumps({'then': then}), '{"then": "2018-11-05"}')
+
+    def test_encode_time(self):
+        then = time(7, 54, 55, 123456)
+        self.assertEqual(self.dumps({'then': then}),
+                         '{"then": "07:54:55.123456"}')
+
+        then = then.replace(tzinfo=timezone.utc)
+        self.assertEqual(self.dumps({'then': then}),
+                         '{"then": "07:54:55.123456+00:00"}')
+
+    def test_encode_duration(self):
+        self.assertEqual(
+            self.dumps({
+                'span': timedelta(days=1, hours=23, minutes=59, seconds=59,
+                                  microseconds=999999),
+            }),
+            '{"span": "PT47H59M59.999999S"}')
+        self.assertEqual(
+            self.dumps({
+                'span': timedelta(days=-15, hours=10, microseconds=1234),
+            }),
+            '{"span": "PT-350H0M0.1234S"}')
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime, time, timedelta, timezone
 from io import StringIO
-from test.test_json import PyTest, CTest
+from uuid import UUID
 
+from test.test_json import PyTest, CTest
 from test.support import bigmemtest, _1G
 
 class TestDump:
@@ -90,6 +91,12 @@ class TestDump:
                 'span': timedelta(days=-15, hours=10, microseconds=1234),
             }),
             '{"span": "PT-350H0M0.1234S"}')
+
+    def test_encode_uuid(self):
+        uuid = UUID('886313E1-3B8A-5372-9B90-0C9AEE199E5D')
+        self.assertEqual(self.dumps({'id': uuid}),
+                         '{"id": "886313e1-3b8a-5372-9b90-0c9aee199e5d"}')
+
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -47,6 +47,14 @@ class TestDump:
         d[1337] = "true.dat"
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
+    def test_encode_jsonformatable_object(self):
+        class C:
+            def jsonformat(self):
+                return 'hi there'
+        
+        self.assertEqual(self.dumps({'v': C()}),
+                         '{"v": "hi there"}')
+
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -266,6 +266,9 @@ class UUID:
         return '%s-%s-%s-%s-%s' % (
             hex[:8], hex[8:12], hex[12:16], hex[16:20], hex[20:])
 
+    def jsonformat(self):
+        return str(self)
+
     @property
     def bytes(self):
         return self.int.to_bytes(16, 'big')

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1501,6 +1501,23 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
         Py_LeaveRecursiveCall();
         return rv;
     }
+    else if (PyObject_HasAttrString(obj, "jsonformat")) {
+        PyObject *to_json = PyObject_GetAttrString(obj, "jsonformat");
+        newobj = PyObject_CallFunctionObjArgs(to_json, NULL);
+        if (Py_EnterRecursiveCall(" while encoding a JSON object")) {
+            Py_CLEAR(newobj);
+            Py_DECREF(to_json);
+            return -1;
+        }
+        rv = encoder_listencode_obj(s, acc, newobj, indent_level);
+        Py_LeaveRecursiveCall();
+        Py_CLEAR(newobj);
+        Py_DECREF(to_json);
+        if (rv) {
+            return -1;
+        }
+        return rv;
+    }
     else {
         PyObject *ident = NULL;
         if (s->markers != Py_None) {


### PR DESCRIPTION
This is what I was envisioning.  The "protocol" is simply a new method that I named `jsonformat` to line up with `isoformat` (no particularly good reason).  The spelling of the method name is up for debate but the remainder of the changes are all that is needed.  Mind you that my C is a little rusty (about six or seven years since I wrote anything production quality there) but I think that I got all of the memory allocation stuff correct.

The basic idea is that the `jsonformat` method is required to return something that can be handled by the JSON encoder or fail.  It is conceptually similar to the `default` method on `json.JSONEncoder`.  There is obviously quite a bit of room for change in any of this.